### PR TITLE
#24_add_status_priority_update_feature

### DIFF
--- a/src/atoms/atom.js
+++ b/src/atoms/atom.js
@@ -9,7 +9,7 @@ export const inputState = atom({
   effects_UNSTABLE: [persistAtom],
 });
 
-export const todoState = atom({
+export const todoListState = atom({
   key: "todoState",
   default: [
     // TodoListダミーデータ

--- a/src/components/PriorityButton.jsx
+++ b/src/components/PriorityButton.jsx
@@ -1,13 +1,20 @@
 import useUpdateTodoState from "../hooks/useUpdateTodoState";
+import { TODO_PRIORITY } from "../constants";
 
 const PriorityButton = ({ todo }) => {
   // ステータス更新用カスタムフック
   const { updateTodoPriority } = useUpdateTodoState();
+  const ButtonStyle = {
+    [TODO_PRIORITY.HIGH]: "table-content-priority table-content-priority-high",
+    [TODO_PRIORITY.NORMAL]:
+      "table-content-priority table-content-priority-normal",
+    [TODO_PRIORITY.LOW]: "table-content-priority table-content-priority-normal",
+  };
   return (
     <>
-      {todo.priority === "高" && (
+      {todo.priority === TODO_PRIORITY.HIGH && (
         <button
-          className="table-content-priority table-content-priority-high"
+          className={ButtonStyle[TODO_PRIORITY.HIGH]}
           onClick={() => {
             updateTodoPriority(todo.id);
           }}
@@ -15,9 +22,9 @@ const PriorityButton = ({ todo }) => {
           {todo.priority}
         </button>
       )}
-      {todo.priority === "中" && (
+      {todo.priority === TODO_PRIORITY.NORMAL && (
         <button
-          className="table-content-priority table-content-priority-normal"
+          className={ButtonStyle[TODO_PRIORITY.NORMAL]}
           onClick={() => {
             updateTodoPriority(todo.id);
           }}
@@ -25,9 +32,9 @@ const PriorityButton = ({ todo }) => {
           {todo.priority}
         </button>
       )}
-      {todo.priority === "低" && (
+      {todo.priority === TODO_PRIORITY.LOW && (
         <button
-          className="table-content-priority table-content-priority-low"
+          className={ButtonStyle[TODO_PRIORITY.LOW]}
           onClick={() => {
             updateTodoPriority(todo.id);
           }}

--- a/src/components/PriorityButton.jsx
+++ b/src/components/PriorityButton.jsx
@@ -1,47 +1,24 @@
+import { PRIORITY_HIGH, PRIORITY_LOW, PRIORITY_NORMAL } from "../constants";
 import useUpdateTodoState from "../hooks/useUpdateTodoState";
-import { TODO_PRIORITY } from "../constants";
 
 const PriorityButton = ({ todo }) => {
   // ステータス更新用カスタムフック
   const { updateTodoPriority } = useUpdateTodoState();
   const ButtonStyle = {
-    [TODO_PRIORITY.HIGH]: "table-content-priority table-content-priority-high",
-    [TODO_PRIORITY.NORMAL]:
-      "table-content-priority table-content-priority-normal",
-    [TODO_PRIORITY.LOW]: "table-content-priority table-content-priority-normal",
+    高: PRIORITY_HIGH,
+    中: PRIORITY_NORMAL,
+    低: PRIORITY_LOW,
   };
   return (
     <>
-      {todo.priority === TODO_PRIORITY.HIGH && (
-        <button
-          className={ButtonStyle[TODO_PRIORITY.HIGH]}
-          onClick={() => {
-            updateTodoPriority(todo.id);
-          }}
-        >
-          {todo.priority}
-        </button>
-      )}
-      {todo.priority === TODO_PRIORITY.NORMAL && (
-        <button
-          className={ButtonStyle[TODO_PRIORITY.NORMAL]}
-          onClick={() => {
-            updateTodoPriority(todo.id);
-          }}
-        >
-          {todo.priority}
-        </button>
-      )}
-      {todo.priority === TODO_PRIORITY.LOW && (
-        <button
-          className={ButtonStyle[TODO_PRIORITY.LOW]}
-          onClick={() => {
-            updateTodoPriority(todo.id);
-          }}
-        >
-          {todo.priority}
-        </button>
-      )}
+      <button
+        className={ButtonStyle[todo.priority]}
+        onClick={() => {
+          updateTodoPriority(todo.id);
+        }}
+      >
+        {todo.priority}
+      </button>
     </>
   );
 };

--- a/src/components/PriorityButton.jsx
+++ b/src/components/PriorityButton.jsx
@@ -1,0 +1,42 @@
+import useUpdateTodoState from "../hooks/useUpdateTodoState";
+
+const PriorityButton = ({ todo }) => {
+  // ステータス更新用カスタムフック
+  const { updateTodoPriority } = useUpdateTodoState();
+  return (
+    <>
+      {todo.priority === "高" && (
+        <button
+          className="table-content-priority table-content-priority-high"
+          onClick={() => {
+            updateTodoPriority(todo.id);
+          }}
+        >
+          {todo.priority}
+        </button>
+      )}
+      {todo.priority === "中" && (
+        <button
+          className="table-content-priority table-content-priority-normal"
+          onClick={() => {
+            updateTodoPriority(todo.id);
+          }}
+        >
+          {todo.priority}
+        </button>
+      )}
+      {todo.priority === "低" && (
+        <button
+          className="table-content-priority table-content-priority-low"
+          onClick={() => {
+            updateTodoPriority(todo.id);
+          }}
+        >
+          {todo.priority}
+        </button>
+      )}
+    </>
+  );
+};
+
+export default PriorityButton;

--- a/src/components/StatusButton.jsx
+++ b/src/components/StatusButton.jsx
@@ -1,46 +1,24 @@
+import { STATUS_DONE, STATUS_PENDING, STATUS_WORKING } from "../constants";
 import useUpdateTodoState from "../hooks/useUpdateTodoState";
-import { TODO_STATUS } from "../constants";
 
 const StatusButton = ({ todo }) => {
   // ステータス更新用カスタムフック
   const { updateTodoStatus } = useUpdateTodoState();
   const ButtonStyle = {
-    [TODO_STATUS.PENDING]: "table-content-status table-content-status-pending",
-    [TODO_STATUS.WORKING]: "table-content-status table-content-status-working",
-    [TODO_STATUS.DONE]: "table-content-status table-content-status-done",
+    未着手: STATUS_PENDING,
+    作業中: STATUS_WORKING,
+    完了: STATUS_DONE,
   };
   return (
     <>
-      {todo.status === TODO_STATUS.PENDING && (
-        <button
-          className={ButtonStyle[TODO_STATUS.PENDING]}
-          onClick={() => {
-            updateTodoStatus(todo.id);
-          }}
-        >
-          {todo.status}
-        </button>
-      )}
-      {todo.status === TODO_STATUS.WORKING && (
-        <button
-          className={ButtonStyle[TODO_STATUS.WORKING]}
-          onClick={() => {
-            updateTodoStatus(todo.id);
-          }}
-        >
-          {todo.status}
-        </button>
-      )}
-      {todo.status === TODO_STATUS.DONE && (
-        <button
-          className={ButtonStyle[TODO_STATUS.DONE]}
-          onClick={() => {
-            updateTodoStatus(todo.id);
-          }}
-        >
-          {todo.status}
-        </button>
-      )}
+      <button
+        className={ButtonStyle[todo.status]}
+        onClick={() => {
+          updateTodoStatus(todo.id);
+        }}
+      >
+        {todo.status}
+      </button>
     </>
   );
 };

--- a/src/components/StatusButton.jsx
+++ b/src/components/StatusButton.jsx
@@ -1,0 +1,42 @@
+import useUpdateTodoState from "../hooks/useUpdateTodoState";
+
+const StatusButton = ({ todo }) => {
+  // ステータス更新用カスタムフック
+  const { updateTodoStatus } = useUpdateTodoState();
+  return (
+    <>
+      {todo.status === "未着手" && (
+        <button
+          className="table-content-status table-content-status-pending"
+          onClick={() => {
+            updateTodoStatus(todo.id);
+          }}
+        >
+          {todo.status}
+        </button>
+      )}
+      {todo.status === "作業中" && (
+        <button
+          className="table-content-status table-content-status-working"
+          onClick={() => {
+            updateTodoStatus(todo.id);
+          }}
+        >
+          {todo.status}
+        </button>
+      )}
+      {todo.status === "完了" && (
+        <button
+          className="table-content-status table-content-status-done"
+          onClick={() => {
+            updateTodoStatus(todo.id);
+          }}
+        >
+          {todo.status}
+        </button>
+      )}
+    </>
+  );
+};
+
+export default StatusButton;

--- a/src/components/StatusButton.jsx
+++ b/src/components/StatusButton.jsx
@@ -1,13 +1,19 @@
 import useUpdateTodoState from "../hooks/useUpdateTodoState";
+import { TODO_STATUS } from "../constants";
 
 const StatusButton = ({ todo }) => {
   // ステータス更新用カスタムフック
   const { updateTodoStatus } = useUpdateTodoState();
+  const ButtonStyle = {
+    [TODO_STATUS.PENDING]: "table-content-status table-content-status-pending",
+    [TODO_STATUS.WORKING]: "table-content-status table-content-status-working",
+    [TODO_STATUS.DONE]: "table-content-status table-content-status-done",
+  };
   return (
     <>
-      {todo.status === "未着手" && (
+      {todo.status === TODO_STATUS.PENDING && (
         <button
-          className="table-content-status table-content-status-pending"
+          className={ButtonStyle[TODO_STATUS.PENDING]}
           onClick={() => {
             updateTodoStatus(todo.id);
           }}
@@ -15,9 +21,9 @@ const StatusButton = ({ todo }) => {
           {todo.status}
         </button>
       )}
-      {todo.status === "作業中" && (
+      {todo.status === TODO_STATUS.WORKING && (
         <button
-          className="table-content-status table-content-status-working"
+          className={ButtonStyle[TODO_STATUS.WORKING]}
           onClick={() => {
             updateTodoStatus(todo.id);
           }}
@@ -25,9 +31,9 @@ const StatusButton = ({ todo }) => {
           {todo.status}
         </button>
       )}
-      {todo.status === "完了" && (
+      {todo.status === TODO_STATUS.DONE && (
         <button
-          className="table-content-status table-content-status-done"
+          className={ButtonStyle[TODO_STATUS.DONE]}
           onClick={() => {
             updateTodoStatus(todo.id);
           }}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,13 @@
+export const TODO_PRIORITY = {
+  ALL: "すべて",
+  HIGH: "高",
+  NORMAL: "中",
+  LOW: "低",
+};
+
+export const TODO_STATUS = {
+  ALL: "すべて",
+  PENDING: "未着手",
+  WORKING: "作業中",
+  DONE: "完了",
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,13 +1,10 @@
-export const TODO_PRIORITY = {
-  ALL: "すべて",
-  HIGH: "高",
-  NORMAL: "中",
-  LOW: "低",
-};
-
-export const TODO_STATUS = {
-  ALL: "すべて",
-  PENDING: "未着手",
-  WORKING: "作業中",
-  DONE: "完了",
-};
+export const PRIORITY_HIGH =
+  "table-content-priority table-content-priority-high";
+export const PRIORITY_NORMAL =
+  "table-content-priority table-content-priority-normal";
+export const PRIORITY_LOW = "table-content-priority table-content-priority-low";
+export const STATUS_PENDING =
+  "table-content-status table-content-status-pending";
+export const STATUS_WORKING =
+  "table-content-status table-content-status-working";
+export const STATUS_DONE = "table-content-status table-content-status-done";

--- a/src/hooks/useUpdateTodoState.jsx
+++ b/src/hooks/useUpdateTodoState.jsx
@@ -1,0 +1,73 @@
+import { todoListState } from "../atoms/atom";
+import { useRecoilState } from "recoil";
+
+// ステータス、優先度更新用カスタムフック
+const useUpdateTodoState = () => {
+  // todoリストデータ
+  const [todoList, setTodoList] = useRecoilState(todoListState);
+
+  // ステータス更新
+  const updateTodoStatus = (id) => {
+    const index = todoList.findIndex((todo) => todo.id === id);
+    setTodoList(() => {
+      switch (todoList[index].status) {
+        case "未着手":
+          return replaceItemAtIndex(todoList, index, {
+            ...todoList[index],
+            status: "作業中",
+          });
+        case "作業中":
+          return replaceItemAtIndex(todoList, index, {
+            ...todoList[index],
+            status: "完了",
+          });
+        case "完了":
+          return replaceItemAtIndex(todoList, index, {
+            ...todoList[index],
+            status: "未着手",
+          });
+        default:
+          return todoList;
+      }
+    });
+  };
+
+  // 優先度更新
+  const updateTodoPriority = (id) => {
+    const index = todoList.findIndex((todo) => todo.id === id);
+    setTodoList(() => {
+      switch (todoList[index].priority) {
+        case "低":
+          return replaceItemAtIndex(todoList, index, {
+            ...todoList[index],
+            priority: "中",
+          });
+        case "中":
+          return replaceItemAtIndex(todoList, index, {
+            ...todoList[index],
+            priority: "高",
+          });
+        case "高":
+          return replaceItemAtIndex(todoList, index, {
+            ...todoList[index],
+            priority: "低",
+          });
+        default:
+          return todoList;
+      }
+    });
+  };
+
+  // 選択されたtodoを新しいtodoに入れ替える処理
+  const replaceItemAtIndex = (todoList, index, newValue) => {
+    return [
+      ...todoList.slice(0, index),
+      newValue,
+      ...todoList.slice(index + 1),
+    ];
+  };
+
+  return { updateTodoStatus, updateTodoPriority };
+};
+
+export default useUpdateTodoState;

--- a/src/routes/ListView.jsx
+++ b/src/routes/ListView.jsx
@@ -1,5 +1,6 @@
 import "../style/ListView.css";
 import Breadcrumb from "../components/Breadcrumb";
+import { useState } from "react";
 
 // ダミーデータ
 const dummyTodoData = [
@@ -33,6 +34,38 @@ const dummyTodoData = [
 const breadcrumbElements = [{ id: 1, title: "ホーム" }];
 
 export const ListView = () => {
+  const [todo, setTodo] = useState(dummyTodoData);
+
+  // ステータス更新
+  const updateTodoStatus = (id) => {
+    const index = todo.findIndex((v) => v.id === id);
+    const updatedTodo = [...todo];
+    if (updatedTodo[index].status === "未着手") {
+      updatedTodo[index].status = "作業中";
+    } else if (updatedTodo[index].status === "作業中") {
+      updatedTodo[index].status = "完了";
+    } else {
+      updatedTodo[index].status = "未着手";
+    }
+
+    setTodo(updatedTodo);
+  };
+
+  // 優先度更新
+  const updateTodoPriority = (id) => {
+    const index = todo.findIndex((v) => v.id === id);
+    const updatedTodo = [...todo];
+    if (updatedTodo[index].priority === "低") {
+      updatedTodo[index].priority = "中";
+    } else if (updatedTodo[index].priority === "中") {
+      updatedTodo[index].priority = "高";
+    } else {
+      updatedTodo[index].priority = "低";
+    }
+
+    setTodo(updatedTodo);
+  };
+
   return (
     <>
       <Breadcrumb breadcrumbElements={breadcrumbElements} />
@@ -99,7 +132,7 @@ export const ListView = () => {
           </thead>
           <tbody>
             {/* ダミーデータを表示 */}
-            {dummyTodoData.map((todo) => {
+            {todo.map((todo) => {
               return (
                 <tr key={todo.id} className="todo-table-body-row">
                   <td>
@@ -111,36 +144,66 @@ export const ListView = () => {
                   </td>
                   <td>
                     {todo.status === "未着手" && (
-                      <p className="table-content-status table-content-status-pending">
+                      <button
+                        className="table-content-status table-content-status-pending"
+                        onClick={() => {
+                          updateTodoStatus(todo.id);
+                        }}
+                      >
                         {todo.status}
-                      </p>
+                      </button>
                     )}
                     {todo.status === "作業中" && (
-                      <p className="table-content-status table-content-status-working">
+                      <button
+                        className="table-content-status table-content-status-working"
+                        onClick={() => {
+                          updateTodoStatus(todo.id);
+                        }}
+                      >
                         {todo.status}
-                      </p>
+                      </button>
                     )}
                     {todo.status === "完了" && (
-                      <p className="table-content-status table-content-status-done">
+                      <button
+                        className="table-content-status table-content-status-done"
+                        onClick={() => {
+                          updateTodoStatus(todo.id);
+                        }}
+                      >
                         {todo.status}
-                      </p>
+                      </button>
                     )}
                   </td>
                   <td>
                     {todo.priority === "高" && (
-                      <p className="table-content-priority-high">
+                      <button
+                        className="table-content-priority table-content-priority-high"
+                        onClick={() => {
+                          updateTodoPriority(todo.id);
+                        }}
+                      >
                         {todo.priority}
-                      </p>
+                      </button>
                     )}
                     {todo.priority === "中" && (
-                      <p className="table-content-priority-normal">
+                      <button
+                        className="table-content-priority table-content-priority-normal"
+                        onClick={() => {
+                          updateTodoPriority(todo.id);
+                        }}
+                      >
                         {todo.priority}
-                      </p>
+                      </button>
                     )}
                     {todo.priority === "低" && (
-                      <p className="table-content-priority-low">
+                      <button
+                        className="table-content-priority table-content-priority-low"
+                        onClick={() => {
+                          updateTodoPriority(todo.id);
+                        }}
+                      >
                         {todo.priority}
-                      </p>
+                      </button>
                     )}
                   </td>
                   <td>{todo.createAt}</td>

--- a/src/routes/ListView.jsx
+++ b/src/routes/ListView.jsx
@@ -6,8 +6,6 @@ import Breadcrumb from "../components/Breadcrumb";
 import StatusButton from "../components/StatusButton";
 import PriorityButton from "../components/PriorityButton";
 
-import { TODO_PRIORITY, TODO_STATUS } from "../constants";
-
 // ぱんくずデータ 画面ごとに変更する
 const breadcrumbElements = [{ id: 1, title: "ホーム" }];
 
@@ -44,19 +42,19 @@ export const ListView = () => {
           <div className="search-priority-area">
             <label className="label-search-area">ステータス</label>
             <select className="search-box">
-              <option defaultValue="all">{TODO_STATUS.ALL}</option>
-              <option value="complete">{TODO_STATUS.DONE}</option>
-              <option value="working">{TODO_STATUS.WORKING}</option>
-              <option value="pending">{TODO_STATUS.PENDING}</option>
+              <option defaultValue="all">すべて</option>
+              <option value="complete">完了</option>
+              <option value="working">作業中</option>
+              <option value="pending">未着手</option>
             </select>
           </div>
           <div className="search-status-area">
             <label className="label-search-area">優先度</label>
             <select className="search-box">
-              <option defaultValue="all">{TODO_PRIORITY.ALL}</option>
-              <option value="high">{TODO_PRIORITY.HIGH}</option>
-              <option value="normal">{TODO_PRIORITY.NORMAL}</option>
-              <option value="low">{TODO_PRIORITY.LOW}</option>
+              <option defaultValue="all">すべて</option>
+              <option value="high">高</option>
+              <option value="normal">中</option>
+              <option value="low">低</option>
             </select>
           </div>
         </div>

--- a/src/routes/ListView.jsx
+++ b/src/routes/ListView.jsx
@@ -1,76 +1,18 @@
-import { todoState } from "../atoms/atom";
-import { useRecoilState } from "recoil";
+import useUpdateTodoState from "../hooks/useUpdateTodoState";
 
 import "../style/ListView.css";
 import Breadcrumb from "../components/Breadcrumb";
+import { useRecoilState } from "recoil";
+import { todoListState } from "../atoms/atom";
+import StatusButton from "../components/StatusButton";
+import PriorityButton from "../components/PriorityButton";
 
 // ぱんくずデータ 画面ごとに変更する
 const breadcrumbElements = [{ id: 1, title: "ホーム" }];
 
 export const ListView = () => {
   // todoリストデータ
-  const [todoList, setTodoList] = useRecoilState(todoState);
-
-  // ステータス更新
-  const updateTodoStatus = (id) => {
-    const index = todoList.findIndex((todo) => todo.id === id);
-    setTodoList(() => {
-      switch (todoList[index].status) {
-        case "未着手":
-          return replaceItemAtIndex(todoList, index, {
-            ...todoList[index],
-            status: "作業中",
-          });
-        case "作業中":
-          return replaceItemAtIndex(todoList, index, {
-            ...todoList[index],
-            status: "完了",
-          });
-        case "完了":
-          return replaceItemAtIndex(todoList, index, {
-            ...todoList[index],
-            status: "未着手",
-          });
-        default:
-          return todoList;
-      }
-    });
-  };
-
-  // 優先度更新
-  const updateTodoPriority = (id) => {
-    const index = todoList.findIndex((todo) => todo.id === id);
-    setTodoList(() => {
-      switch (todoList[index].priority) {
-        case "低":
-          return replaceItemAtIndex(todoList, index, {
-            ...todoList[index],
-            priority: "中",
-          });
-        case "中":
-          return replaceItemAtIndex(todoList, index, {
-            ...todoList[index],
-            priority: "高",
-          });
-        case "高":
-          return replaceItemAtIndex(todoList, index, {
-            ...todoList[index],
-            priority: "低",
-          });
-        default:
-          return todoList;
-      }
-    });
-  };
-
-  // 選択されたtodoを新しいtodoに入れ替える処理
-  const replaceItemAtIndex = (todoList, index, newValue) => {
-    return [
-      ...todoList.slice(0, index),
-      newValue,
-      ...todoList.slice(index + 1),
-    ];
-  };
+  const [todoList, setTodoList] = useRecoilState(todoListState);
 
   return (
     <>
@@ -151,68 +93,10 @@ export const ListView = () => {
                     <button className="btn-edit">✎</button>
                   </td>
                   <td>
-                    {todo.status === "未着手" && (
-                      <button
-                        className="table-content-status table-content-status-pending"
-                        onClick={() => {
-                          updateTodoStatus(todo.id);
-                        }}
-                      >
-                        {todo.status}
-                      </button>
-                    )}
-                    {todo.status === "作業中" && (
-                      <button
-                        className="table-content-status table-content-status-working"
-                        onClick={() => {
-                          updateTodoStatus(todo.id);
-                        }}
-                      >
-                        {todo.status}
-                      </button>
-                    )}
-                    {todo.status === "完了" && (
-                      <button
-                        className="table-content-status table-content-status-done"
-                        onClick={() => {
-                          updateTodoStatus(todo.id);
-                        }}
-                      >
-                        {todo.status}
-                      </button>
-                    )}
+                    <StatusButton todo={todo} />
                   </td>
                   <td>
-                    {todo.priority === "高" && (
-                      <button
-                        className="table-content-priority table-content-priority-high"
-                        onClick={() => {
-                          updateTodoPriority(todo.id);
-                        }}
-                      >
-                        {todo.priority}
-                      </button>
-                    )}
-                    {todo.priority === "中" && (
-                      <button
-                        className="table-content-priority table-content-priority-normal"
-                        onClick={() => {
-                          updateTodoPriority(todo.id);
-                        }}
-                      >
-                        {todo.priority}
-                      </button>
-                    )}
-                    {todo.priority === "低" && (
-                      <button
-                        className="table-content-priority table-content-priority-low"
-                        onClick={() => {
-                          updateTodoPriority(todo.id);
-                        }}
-                      >
-                        {todo.priority}
-                      </button>
-                    )}
+                    <PriorityButton todo={todo} />
                   </td>
                   <td>{todo.createAt}</td>
                   <td>{todo.updateAt}</td>

--- a/src/routes/ListView.jsx
+++ b/src/routes/ListView.jsx
@@ -1,18 +1,19 @@
-import useUpdateTodoState from "../hooks/useUpdateTodoState";
+import { useRecoilValue } from "recoil";
+import { todoListState } from "../atoms/atom";
 
 import "../style/ListView.css";
 import Breadcrumb from "../components/Breadcrumb";
-import { useRecoilState } from "recoil";
-import { todoListState } from "../atoms/atom";
 import StatusButton from "../components/StatusButton";
 import PriorityButton from "../components/PriorityButton";
+
+import { TODO_PRIORITY, TODO_STATUS } from "../constants";
 
 // ぱんくずデータ 画面ごとに変更する
 const breadcrumbElements = [{ id: 1, title: "ホーム" }];
 
 export const ListView = () => {
   // todoリストデータ
-  const [todoList, setTodoList] = useRecoilState(todoListState);
+  const todoList = useRecoilValue(todoListState);
 
   return (
     <>
@@ -43,19 +44,19 @@ export const ListView = () => {
           <div className="search-priority-area">
             <label className="label-search-area">ステータス</label>
             <select className="search-box">
-              <option defaultValue="all">すべて</option>
-              <option value="complete">完了</option>
-              <option value="working">作業中</option>
-              <option value="pending">未着手</option>
+              <option defaultValue="all">{TODO_STATUS.ALL}</option>
+              <option value="complete">{TODO_STATUS.DONE}</option>
+              <option value="working">{TODO_STATUS.WORKING}</option>
+              <option value="pending">{TODO_STATUS.PENDING}</option>
             </select>
           </div>
           <div className="search-status-area">
             <label className="label-search-area">優先度</label>
             <select className="search-box">
-              <option defaultValue="all">すべて</option>
-              <option value="high">高</option>
-              <option value="normal">中</option>
-              <option value="low">低</option>
+              <option defaultValue="all">{TODO_PRIORITY.ALL}</option>
+              <option value="high">{TODO_PRIORITY.HIGH}</option>
+              <option value="normal">{TODO_PRIORITY.NORMAL}</option>
+              <option value="low">{TODO_PRIORITY.LOW}</option>
             </select>
           </div>
         </div>

--- a/src/style/ListView.css
+++ b/src/style/ListView.css
@@ -159,6 +159,7 @@ main {
   line-height: 30px;
   text-align: center;
   border-radius: 25px;
+  border: none;
 }
 
 .table-content-status-pending {
@@ -179,6 +180,11 @@ main {
 /* ------------------------------
   テーブル 優先度表示
 ------------------------------ */
+.table-content-priority {
+  border: none;
+  background-color: transparent;
+}
+
 .table-content-priority-high::before {
   content: "";
   width: 20px;


### PR DESCRIPTION
closes if-tech-support/todo_team#24

## IssueのURL
https://github.com/if-tech-support/todo_team/issues/24#issue-1054805230

## 対応内容・対応背景・妥協点
1. recoilでデータ管理するように変更
2. ステータスをボタン押下することで更新（未実施→実施中、実施中→完了、完了→未実施）するよう対応
3. 優先度をボタン押下することで更新（低→中、中→高、高→低）するよう対応

## やったこと
- atom.jsにダミーデータを移動、atom.jsからデータを取り出す、更新するように変更
- listview table ステータス, 優先度をpタグからbuttonタグへ変更
- button押下時の処理をそれぞれupdateTodoStatus, updateTodoPriorityに記載
  ボタン押下時にidを引数に取り、updateTodoStatus, updateTodoPriorityに渡す
  該当のtodoのみ値を変更するための処理をreplaceItemAtIndexに記載

## やってないこと
- 特になし

## UI before / after
- 特になし

## テスト
- console.logでステータス、優先度ボタン押下時のリストデータが更新されていることを確認