### PR TITLE
#26_count_task_feature

### DIFF
--- a/src/routes/ListView.jsx
+++ b/src/routes/ListView.jsx
@@ -23,7 +23,17 @@ export const ListView = () => {
       <main>
         <div className="task-info-area">
           <p className="task-info">
-            進行中のタスクは<span>3個</span>あります
+            進行中のタスクは
+            {todoList.filter((todo) => todo.status !== "完了").length !== 0 ? (
+              <>
+                <span>
+                  {todoList.filter((todo) => todo.status !== "完了").length}個
+                </span>
+                あります
+              </>
+            ) : (
+              "ありません"
+            )}
           </p>
           <button className="btn-add">
             <span>+</span>タスクを追加


### PR DESCRIPTION
closes #26

## IssueのURL
https://github.com/if-tech-support/todo_team/issues/26#issue-1054836566

## 対応内容・対応背景・妥協点
- 残タスクの表示

## やったこと
- todoリストデータのステータスの値が完了以外のものを抽出し、数をカウント
- 完了以外のものが1以上の場合は数を表示、0の場合はタスクがないことを表示

## やってないこと・できていないこと
- 特になし

## UI before / after
- 特になし

## テスト
- ブラウザ上でステータスを変更した際の挙動を確認